### PR TITLE
Allow using package-specific vendor files

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -23,6 +23,7 @@ class Controller extends Package
     public function on_start()
     {
         $this->app->make(RouterInterface::class)->register('/graphql', 'Concrete5GraphqlWebsocket\Api::view');
+        $this->registerAutoload();
         Websocket::run();
     }
 
@@ -58,5 +59,13 @@ class Controller extends Package
     private function installXML()
     {
         $this->installContentFile('config/install.xml');
+    }
+
+    private function registerAutoload()
+    {
+        $autoloader = $this->getPackagePath() . '/vendor/autoload.php';
+        if (file_exists($autoloader)) {
+            require_once $autoloader;
+        }
     }
 }


### PR DESCRIPTION
You can install composer dependencies in your package directory by using the `composerpkg` command that you can find at https://github.com/concrete5/cli/pull/4:
Simply run `composerpkg install` in a terminal console (the current directory must be the package root directory).
This allows creating the `vendor` directory and its `vendor/autoload.php` file at the package level, and the changes in this PR allows loading it.